### PR TITLE
feat: add WebSite, WebPage, LocalBusiness and ContactPage structured data

### DIFF
--- a/EventListeners/StoreMicroDataListener.php
+++ b/EventListeners/StoreMicroDataListener.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace SEOne\EventListeners;
+
+use SEOne\Event\SEOneStoreMicroDataEvent;
+use SEOne\Event\SEOneStoreMicroDataEvents;
+use SEOne\Service\LocalBusinessFactory;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * Upgrades the default store microdata (Organization) to a richer LocalBusiness node on every
+ * object-based view (product, category, folder, content, page...).
+ *
+ * @see https://schema.org/LocalBusiness
+ */
+#[AsEventListener(event: SEOneStoreMicroDataEvents::BETTER_SEO_STORE_MICRO_DATA)]
+final readonly class StoreMicroDataListener
+{
+    public function __construct(
+        private LocalBusinessFactory $localBusinessFactory,
+    ) {
+    }
+
+    public function __invoke(SEOneStoreMicroDataEvent $event): void
+    {
+        $business = ['@context' => 'https://schema.org'] + $this->localBusinessFactory->build($event->getLocale());
+
+        $event->setStoreMicrodata($business);
+    }
+}

--- a/Service/LocalBusinessFactory.php
+++ b/Service/LocalBusinessFactory.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace SEOne\Service;
+
+use SEOne\SEOne;
+use Thelia\Domain\Localization\Service\LangService;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\CountryQuery;
+
+/**
+ * Single source of truth for the store LocalBusiness JSON-LD node, built from the Thelia
+ * store configuration. Reused by the store-microdata listener (global object views) and by
+ * the Home/Contact SEO services.
+ *
+ * The returned node carries no @context: callers embed it in a graph (which owns the
+ * @context) or wrap it themselves for a standalone <script>.
+ *
+ * The business image/logo is taken from the $image argument when provided, otherwise from the
+ * SEOne "store_image" configuration value (absolute URL); when both are empty it is omitted.
+ *
+ * @see https://schema.org/LocalBusiness
+ */
+final readonly class LocalBusinessFactory
+{
+    public function __construct(
+        private LangService $langService,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(?string $locale = null, ?string $image = null): array
+    {
+        $locale ??= $this->langService->getLocale();
+        $image ??= SEOne::getConfigValue('store_image');
+        $siteUrl = rtrim((string) ConfigQuery::read('url_site'), '/');
+        $country = CountryQuery::create()->filterById((int) ConfigQuery::read('store_country', 64))->findOne();
+
+        $business = [
+            '@type' => 'LocalBusiness',
+            '@id' => $siteUrl.'/#business',
+            'name' => ConfigQuery::read('store_name'),
+            'description' => SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $locale),
+            'url' => $siteUrl.'/',
+            'address' => [
+                '@type' => 'PostalAddress',
+                'streetAddress' => trim(implode(' ', array_filter([
+                    ConfigQuery::read('store_address1'),
+                    ConfigQuery::read('store_address2'),
+                    ConfigQuery::read('store_address3'),
+                ]))),
+                'addressLocality' => ConfigQuery::read('store_city'),
+                'postalCode' => ConfigQuery::read('store_zipcode'),
+                'addressCountry' => $country?->getIsoalpha2(),
+            ],
+        ];
+
+        if ($image) {
+            $business['image'] = $image;
+            $business['logo'] = $image;
+        }
+        if ($phone = ConfigQuery::read('store_phone')) {
+            $business['telephone'] = $phone;
+        }
+        if ($fax = ConfigQuery::read('store_fax')) {
+            $business['faxNumber'] = $fax;
+        }
+        if ($email = ConfigQuery::read('store_email')) {
+            $business['email'] = $email;
+        }
+
+        // Extension points — fill in once the data is available in configuration:
+        //   $business['geo'] = ['@type' => 'GeoCoordinates', 'latitude' => ..., 'longitude' => ...];
+        //   $business['openingHoursSpecification'] = [...];
+        //   $business['sameAs'] = ['https://www.facebook.com/...', ...];
+        //   $business['priceRange'] = '€€';
+
+        return $business;
+    }
+}

--- a/Twig/Plugins/SEOneStructuredDataPluginTwig.php
+++ b/Twig/Plugins/SEOneStructuredDataPluginTwig.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace SEOne\Twig\Plugins;
+
+use SEOne\Service\LocalBusinessFactory;
+use SEOne\Service\SeoToolsService;
+use Thelia\Domain\Localization\Service\LangService;
+use Thelia\Model\ConfigQuery;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Exposes one Twig function per schema.org type so themes can drop structured data exactly
+ * where they want it, e.g. in <head>:
+ *   {{ SEOneWebSite() }}
+ *   {{ SEOneWebPage() }}
+ *   {{ SEOneContactPage() }}
+ *   {{ SEOneLocalBusiness(absolute_url(asset('dist/images/logo.png'))) }}
+ *   {{ SEOneBreadcrumbList([{ name: 'Home', url: '/' }, { name: 'Contact' }]) }}
+ *
+ * Each function returns a standalone <script type="application/ld+json"> block. Nodes are
+ * linked through shared @id anchors (#website, #webpage, #business) so they cross-reference
+ * even when emitted as separate blocks.
+ *
+ * @see https://schema.org/WebSite
+ * @see https://schema.org/WebPage
+ * @see https://schema.org/ContactPage
+ * @see https://schema.org/LocalBusiness
+ * @see https://developers.google.com/search/docs/appearance/structured-data/breadcrumb
+ */
+class SEOneStructuredDataPluginTwig extends AbstractExtension
+{
+    public function __construct(
+        private readonly LocalBusinessFactory $localBusinessFactory,
+        private readonly SeoToolsService $toolsService,
+        private readonly LangService $langService,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('SEOneWebSite', [$this, 'renderWebSite'], ['is_safe' => ['html']]),
+            new TwigFunction('SEOneWebPage', [$this, 'renderWebPage'], ['is_safe' => ['html']]),
+            new TwigFunction('SEOneContactPage', [$this, 'renderContactPage'], ['is_safe' => ['html']]),
+            new TwigFunction('SEOneLocalBusiness', [$this, 'renderLocalBusiness'], ['is_safe' => ['html']]),
+            new TwigFunction('SEOneBreadcrumbList', [$this, 'renderBreadcrumbList'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function renderWebSite(): string
+    {
+        $siteUrl = $this->siteUrl();
+
+        return $this->script([
+            '@type' => 'WebSite',
+            '@id' => $siteUrl.'/#website',
+            'url' => $siteUrl.'/',
+            'name' => ConfigQuery::read('store_name'),
+            'inLanguage' => $this->language(),
+            'publisher' => ['@id' => $siteUrl.'/#business'],
+        ]);
+    }
+
+    public function renderWebPage(?string $name = null, ?string $description = null, ?string $url = null): string
+    {
+        return $this->script($this->pageNode('WebPage', 'webpage', $name, $description, $url));
+    }
+
+    public function renderContactPage(?string $name = null, ?string $description = null, ?string $url = null): string
+    {
+        return $this->script($this->pageNode('ContactPage', 'contactpage', $name, $description, $url));
+    }
+
+    public function renderLocalBusiness(?string $image = null): string
+    {
+        return $this->script($this->localBusinessFactory->build($this->langService->getLocale(), $image));
+    }
+
+    /**
+     * @param array<int, array{name?: string, url?: string}> $items ordered from root to current page
+     */
+    public function renderBreadcrumbList(array $items): string
+    {
+        if ([] === $items) {
+            return '';
+        }
+
+        $elements = [];
+        foreach (array_values($items) as $index => $item) {
+            $element = [
+                '@type' => 'ListItem',
+                'position' => $index + 1,
+                'name' => $item['name'] ?? '',
+            ];
+            if (!empty($item['url'])) {
+                $element['item'] = $item['url'];
+            }
+            $elements[] = $element;
+        }
+
+        return $this->script([
+            '@type' => 'BreadcrumbList',
+            'itemListElement' => $elements,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pageNode(string $type, string $anchor, ?string $name, ?string $description, ?string $url): array
+    {
+        $siteUrl = $this->siteUrl();
+        $view = $this->toolsService->getPageView() ?? '';
+        $viewId = null !== ($id = $this->toolsService->getPageId($view)) ? (int) $id : null;
+
+        $name ??= $this->toolsService->getSeoPageTitle($view, $viewId);
+        $description ??= $this->toolsService->getSeoPageDesc($view, $viewId);
+        $url ??= $this->toolsService->getPageCanonical();
+
+        return [
+            '@type' => $type,
+            '@id' => $url.'#'.$anchor,
+            'url' => $url,
+            'name' => $name,
+            'description' => $description,
+            'inLanguage' => $this->language(),
+            'isPartOf' => ['@id' => $siteUrl.'/#website'],
+            'about' => ['@id' => $siteUrl.'/#business'],
+        ];
+    }
+
+    private function siteUrl(): string
+    {
+        return rtrim((string) ConfigQuery::read('url_site'), '/');
+    }
+
+    private function language(): string
+    {
+        return str_replace('_', '-', $this->langService->getLocale());
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function script(array $node): string
+    {
+        return '<script type="application/ld+json">'
+            .json_encode(['@context' => 'https://schema.org'] + $node, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES)
+            .'</script>';
+    }
+}


### PR DESCRIPTION
## Summary
Adds JSON-LD structured data through the existing SEO service / event system.

- **LocalBusinessFactory** — builds a `LocalBusiness` node from the store configuration (single source of truth). Image/logo read from a `store_image` config value (absolute URL, omitted when empty). Extension points for `geo`, `openingHoursSpecification`, `sameAs`, `priceRange`.
- **StoreMicroDataListener** — upgrades the default store microdata (`Organization`) to `LocalBusiness` on every object-based view, via `better.seo.store.micro.data`.
- **HomeSEO** (`seone.type`) — `WebSite` + `WebPage` + `LocalBusiness` `@graph` on the home view. Home view name configurable via a `home_view` config value (default `index`).
- **ContactSEO** (`seone.type`) — `ContactPage` + `BreadcrumbList` + `LocalBusiness` `@graph` on the `contact` view.

## Notes
- Defaults keep behaviour generic (home view `index`, no image when unset) — no breaking change.
- Config values `home_view` / `store_image` are read via `SEOne::getConfigValue`; adding matching back-office form fields could be a nice follow-up.

Refs: schema.org WebSite / WebPage / LocalBusiness / ContactPage, Google BreadcrumbList