### PR TITLE
Fall back to the default SEO service when the Page module is absent

### DIFF
--- a/Service/SeoDefaultModels/PageSEO.php
+++ b/Service/SeoDefaultModels/PageSEO.php
@@ -35,7 +35,9 @@ readonly class PageSEO implements SeoElementInterface
 
     public function supports(string $view): bool
     {
-        return $view === $this->getView();
+        // The Page module is not a dependency of SEOne: without it, every query
+        // below is a fatal error, so hand the view over to the default SEO service.
+        return $view === $this->getView() && class_exists(PageQuery::class);
     }
 
     public function getIdentifier(): string


### PR DESCRIPTION
### Symptom

On a Thelia 3 install where the Page module is not installed, any request whose
view is `page` is a 500:

```
Class "Page\Model\Base\PageQuery" not found in "@SEOneModule/theme-hook/head-top.html.twig" at line 1
```

It shows up on the 404 page itself: Thelia keeps `_view = page` while rendering
the error template, so the head hook still asks `SeoManager` for the SEO service
of that view.

### Cause

`Service/SeoDefaultModels/PageSEO.php:15-16` imports `Page\Model\Base\PageQuery`
and `Page\Model\Page`, but `composer.json` only requires `thelia/installer` —
the Page module is not a dependency. `SeoManager::getSeoServiceByView()` picks
`PageSEO` on `supports('page') === true` and every method then calls
`PageQuery::create()` on a class that does not exist.

### Fix

`supports()` also checks that the class is loadable. When the Page module is
absent, `SeoManager` falls through to the default SEO service, which is what it
already does for any view no service claims.

### Verified

Fresh Thelia 3 install with demo data, Flexy front, Page module not installed.
`/page` went from 500 (`Class "Page\Model\Base\PageQuery" not found`) to a clean
404. The guarded branch is unchanged when the module is installed: `class_exists`
is true and the service is selected exactly as before.
