### PR TITLE
Fix/i18n default language fallback

### DIFF
--- a/Event/SEOneBreadcrumbEvent.php
+++ b/Event/SEOneBreadcrumbEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Thelia package.
  * http://www.thelia.net
@@ -19,6 +21,7 @@ class SEOneBreadcrumbEvent extends ActionEvent
     protected string $view;
     protected ?int $view_id;
     protected $parameters = [];
+    protected array $breadcrumb = [];
     public const BETTER_SEO_BREADCRUMB = 'seone.page.breadcrumb';
 
     public function __construct(string $view, ?int $view_id, ?array $parameters)

--- a/Service/SeoDefaultModels/CategorySEO.php
+++ b/Service/SeoDefaultModels/CategorySEO.php
@@ -28,6 +28,7 @@ use Thelia\Model\ProductQuery;
 
 readonly class CategorySEO implements SeoElementInterface
 {
+    use LocalizedValueTrait;
     use SeoneBreadcrumbTrait;
 
     public function __construct(
@@ -89,16 +90,20 @@ readonly class CategorySEO implements SeoElementInterface
 
     public function getSeoPageTitle($id): string
     {
-        $category = CategoryQuery::create()->filterById($id)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $category = CategoryQuery::create()->filterById($id)->findOne();
+        $title = $this->firstLocalizedValue($category, ['getMetaTitle', 'getTitle'], $locale);
 
-        return $category?->getMetaTitle() ?? $category?->getTitle() ?? SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $this->langService->getLocale()) ?? '';
+        return '' !== $title ? $title : (SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $locale) ?? '');
     }
 
     public function getSeoPageDesc($id): string
     {
-        $category = CategoryQuery::create()->filterById($id)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $category = CategoryQuery::create()->filterById($id)->findOne();
+        $description = $this->localizedValue($category, 'getMetaDescription', $locale);
 
-        return $category?->getMetaDescription() ?? SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $this->langService->getLocale()) ?? '';
+        return '' !== $description ? $description : (SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $locale) ?? '');
     }
 
     public function getSeoPageH1($id, string $type): string
@@ -116,9 +121,10 @@ readonly class CategorySEO implements SeoElementInterface
         if (null !== $query && $query->getVirtualColumn('h1')) {
             return $query->getVirtualColumn('h1');
         }
-        $category = CategoryQuery::create()->filterById($id)->findOne()?->setLocale($locale);
+        $category = CategoryQuery::create()->filterById($id)->findOne();
+        $title = $this->localizedValue($category, 'getTitle', $locale);
 
-        return $category?->getTitle() ?? ConfigQuery::read('store_name') ?? '';
+        return '' !== $title ? $title : (ConfigQuery::read('store_name') ?? '');
     }
 
     private function getCategoryMicroData(Category $category, Lang $lang, $page, $limit)
@@ -160,15 +166,16 @@ readonly class CategorySEO implements SeoElementInterface
 
     public function getCategoryPath(int $categoryId, ?array $path = []): array
     {
-        $category = CategoryQuery::create()->filterById($categoryId)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $category = CategoryQuery::create()->filterById($categoryId)->findOne();
 
         if (null === $category) {
             return $path;
         }
 
         $path[] = [
-            'url' => $category->getUrl(),
-            'title' => $category->getTitle(),
+            'url' => $category->setLocale($locale)->getUrl(),
+            'title' => $this->localizedValue($category, 'getTitle', $locale),
         ];
 
         $parent = $category->getParent();

--- a/Service/SeoDefaultModels/ContentSEO.php
+++ b/Service/SeoDefaultModels/ContentSEO.php
@@ -25,6 +25,7 @@ use Thelia\Model\Lang;
 
 readonly class ContentSEO implements SeoElementInterface
 {
+    use LocalizedValueTrait;
     use SEOneMicroDataTrait;
 
     public function __construct(
@@ -67,16 +68,20 @@ readonly class ContentSEO implements SeoElementInterface
 
     public function getSeoPageTitle($id): string
     {
-        $content = ContentQuery::create()->filterById($id)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $content = ContentQuery::create()->filterById($id)->findOne();
+        $title = $this->firstLocalizedValue($content, ['getMetaTitle', 'getTitle'], $locale);
 
-        return $content?->getMetaTitle() ?? $content?->getTitle() ?? SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $this->langService->getLocale()) ?? '';
+        return '' !== $title ? $title : (SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $locale) ?? '');
     }
 
     public function getSeoPageDesc($id): string
     {
-        $content = ContentQuery::create()->filterById($id)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $content = ContentQuery::create()->filterById($id)->findOne();
+        $description = $this->localizedValue($content, 'getMetaDescription', $locale);
 
-        return $content?->getMetaDescription() ?? SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $this->langService->getLocale()) ?? '';
+        return '' !== $description ? $description : (SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $locale) ?? '');
     }
 
     public function getSeoPageH1($id, string $type): string
@@ -94,9 +99,12 @@ readonly class ContentSEO implements SeoElementInterface
         if (null !== $query && $query->getVirtualColumn('h1')) {
             return $query->getVirtualColumn('h1');
         }
-        $content = ContentQuery::create()->filterById($id)->useI18nQuery($locale)->endUse()->findOne();
+        // Plain lookup, not useI18nQuery(): an inner join on the requested locale would
+        // hide the content entirely instead of letting the default language answer.
+        $content = ContentQuery::create()->filterById($id)->findOne();
+        $title = $this->localizedValue($content, 'getTitle', $locale);
 
-        return $content?->getTitle() ?? ConfigQuery::read('store_name') ?? '';
+        return '' !== $title ? $title : (ConfigQuery::read('store_name') ?? '');
     }
 
     private function getContentMicroData($contentId, Lang $lang): ?array
@@ -107,14 +115,15 @@ readonly class ContentSEO implements SeoElementInterface
             return null;
         }
 
-        $content->setLocale($lang->getLocale());
+        $locale = $lang->getLocale();
+        $content->setLocale($locale);
 
         $microData = [
             '@context' => 'https://schema.org/',
             '@type' => 'Article',
             'url' => $content->getUrl(),
-            'name' => $content->getTitle(),
-            'abstract' => $content->getChapo(),
+            'name' => $this->localizedValue($content, 'getTitle', $locale),
+            'abstract' => $this->localizedValue($content, 'getChapo', $locale),
         ];
 
         $defaultFoIdlder = $content->getDefaultFolderId();
@@ -122,9 +131,9 @@ readonly class ContentSEO implements SeoElementInterface
         if (null !== $defaultFoIdlder) {
             $default_folder = FolderQuery::create()->findOneById($defaultFoIdlder);
             if (null !== $default_folder) {
-                $default_folder->setLocale($lang->getLocale());
+                $default_folder->setLocale($locale);
                 $microData['isPartOf'] = [
-                    'name' => $default_folder->getTitle(),
+                    'name' => $this->localizedValue($default_folder, 'getTitle', $locale),
                     'url' => $default_folder->getUrl(),
                 ];
             }
@@ -142,15 +151,16 @@ readonly class ContentSEO implements SeoElementInterface
                 ->filterByContentId($id)
                 ->findOne();
 
-            $content = $contentFolder?->getContent()?->setlocale($this->langService->getLocale());
+            $locale = $this->langService->getLocale();
+            $content = $contentFolder?->getContent();
 
             if (null === $content) {
                 return $breadcrumb;
             }
 
             $breadcrumb[] = [
-                'url' => $content->getUrl(),
-                'title' => $content->getTitle(),
+                'url' => $content->setLocale($locale)->getUrl(),
+                'title' => $this->localizedValue($content, 'getTitle', $locale),
             ];
             $breadcrumb = array_reverse($this->folderSeo->getFolderPath($contentFolder->getFolderId(), $breadcrumb));
         }

--- a/Service/SeoDefaultModels/FolderSEO.php
+++ b/Service/SeoDefaultModels/FolderSEO.php
@@ -24,6 +24,7 @@ use Thelia\Model\Lang;
 
 readonly class FolderSEO implements SeoElementInterface
 {
+    use LocalizedValueTrait;
     use SEOneMicroDataTrait;
 
     public function __construct(
@@ -70,16 +71,20 @@ readonly class FolderSEO implements SeoElementInterface
 
     public function getSeoPageTitle($id): string
     {
-        $folder = FolderQuery::create()->filterById($id)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $folder = FolderQuery::create()->filterById($id)->findOne();
+        $title = $this->firstLocalizedValue($folder, ['getMetaTitle', 'getTitle'], $locale);
 
-        return $folder?->getMetaTitle() ?? $folder?->getTitle() ?? SEOne::getConfigValue('title', ConfigQuery::read('store_name'), $this->langService->getLocale()) ?? '';
+        return '' !== $title ? $title : (SEOne::getConfigValue('title', ConfigQuery::read('store_name'), $locale) ?? '');
     }
 
     public function getSeoPageDesc($id): string
     {
-        $folder = FolderQuery::create()->filterById($id)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $folder = FolderQuery::create()->filterById($id)->findOne();
+        $description = $this->localizedValue($folder, 'getMetaDescription', $locale);
 
-        return $folder?->getMetaDescription() ?? SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $this->langService->getLocale()) ?? '';
+        return '' !== $description ? $description : (SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $locale) ?? '');
     }
 
     public function getSeoPageH1($id, string $type): string
@@ -97,21 +102,25 @@ readonly class FolderSEO implements SeoElementInterface
         if (null !== $query && $query->getVirtualColumn('h1')) {
             return $query->getVirtualColumn('h1');
         }
-        $folder = FolderQuery::create()->filterById($id)->useI18nQuery($locale)->endUse()->findOne();
+        // Plain lookup, not useI18nQuery(): an inner join on the requested locale would
+        // hide the folder entirely instead of letting the default language answer.
+        $folder = FolderQuery::create()->filterById($id)->findOne();
+        $title = $this->localizedValue($folder, 'getTitle', $locale);
 
-        return $folder?->getTitle() ?? ConfigQuery::read('store_name') ?? '';
+        return '' !== $title ? $title : (ConfigQuery::read('store_name') ?? '');
     }
 
     private function getFolderMicroData(Folder $folder, Lang $lang): array
     {
-        $folder->setLocale($lang->getLocale());
+        $locale = $lang->getLocale();
+        $folder->setLocale($locale);
 
         $microData = [
             '@context' => 'https://schema.org/',
             '@type' => 'Guide',
             'url' => $folder->getUrl(),
-            'name' => $folder->getTitle(),
-            'abstract' => $folder->getChapo(),
+            'name' => $this->localizedValue($folder, 'getTitle', $locale),
+            'abstract' => $this->localizedValue($folder, 'getChapo', $locale),
         ];
 
         return $microData;
@@ -130,15 +139,16 @@ readonly class FolderSEO implements SeoElementInterface
 
     public function getFolderPath(int $fodlerId, ?array $path = []): array
     {
-        $folder = FolderQuery::create()->filterById($fodlerId)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $folder = FolderQuery::create()->filterById($fodlerId)->findOne();
 
         if (null === $folder) {
             return $path;
         }
 
         $path[] = [
-            'url' => $folder->getUrl(),
-            'title' => $folder->getTitle(),
+            'url' => $folder->setLocale($locale)->getUrl(),
+            'title' => $this->localizedValue($folder, 'getTitle', $locale),
         ];
 
         $parent = $folder->getParent();

--- a/Service/SeoDefaultModels/LocalizedValueTrait.php
+++ b/Service/SeoDefaultModels/LocalizedValueTrait.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SEOne\Service\SeoDefaultModels;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Lang;
+
+/**
+ * Reads i18n columns the way the rest of Thelia does: when the requested locale has no
+ * translation, honour the back-office setting "Si une traduction est absente ou incomplète"
+ * (config key default_lang_without_translation) instead of returning an empty value.
+ */
+trait LocalizedValueTrait
+{
+    private function localizedValue(?ActiveRecordInterface $record, string $getter, string $locale): string
+    {
+        if (null === $record) {
+            return '';
+        }
+
+        $value = $record->setLocale($locale)->{$getter}();
+
+        // Explicit emptiness test rather than ?: — "0" is a legitimate title.
+        if (null !== $value && '' !== $value) {
+            return (string) $value;
+        }
+
+        $fallbackLocale = $this->fallbackLocale($locale);
+
+        if (null === $fallbackLocale) {
+            return '';
+        }
+
+        $value = $record->setLocale($fallbackLocale)->{$getter}();
+
+        // The record must keep serving the requested locale: getUrl() and any later read
+        // are not supposed to switch language behind our back.
+        $record->setLocale($locale);
+
+        return null === $value ? '' : (string) $value;
+    }
+
+    /**
+     * @param array<string> $getters
+     */
+    private function firstLocalizedValue(?ActiveRecordInterface $record, array $getters, string $locale): string
+    {
+        foreach ($getters as $getter) {
+            $value = $this->localizedValue($record, $getter, $locale);
+
+            if ('' !== $value) {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    private function fallbackLocale(string $currentLocale): ?string
+    {
+        // STRICTLY_USE_REQUESTED_LANGUAGE: the admin asked for no substitution at all.
+        if (Lang::REPLACE_BY_DEFAULT_LANGUAGE !== (int) ConfigQuery::getDefaultLangWhenNoTranslationAvailable()) {
+            return null;
+        }
+
+        $defaultLocale = Lang::getDefaultLanguage()->getLocale();
+
+        return $defaultLocale === $currentLocale ? null : $defaultLocale;
+    }
+}

--- a/Service/SeoDefaultModels/PageSEO.php
+++ b/Service/SeoDefaultModels/PageSEO.php
@@ -24,6 +24,7 @@ use Thelia\Model\Lang;
 
 readonly class PageSEO implements SeoElementInterface
 {
+    use LocalizedValueTrait;
     use SEOneMicroDataTrait;
 
     public function __construct(
@@ -72,16 +73,20 @@ readonly class PageSEO implements SeoElementInterface
 
     public function getSeoPageTitle($id): string
     {
-        $page = PageQuery::create()->filterById($id)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $page = PageQuery::create()->filterById($id)->findOne();
+        $title = $this->firstLocalizedValue($page, ['getMetaTitle', 'getTitle'], $locale);
 
-        return $page?->getMetaTitle() ?? $page?->getTitle() ?? SEOne::getConfigValue('title', ConfigQuery::read('store_name'), $this->langService->getLocale()) ?? '';
+        return '' !== $title ? $title : (SEOne::getConfigValue('title', ConfigQuery::read('store_name'), $locale) ?? '');
     }
 
     public function getSeoPageDesc($id): string
     {
-        $page = PageQuery::create()->filterById($id)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $page = PageQuery::create()->filterById($id)->findOne();
+        $description = $this->localizedValue($page, 'getMetaDescription', $locale);
 
-        return $page?->getMetaDescription() ?? SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $this->langService->getLocale()) ?? '';
+        return '' !== $description ? $description : (SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $locale) ?? '');
     }
 
     public function getSeoPageH1($id, string $type): string
@@ -99,21 +104,25 @@ readonly class PageSEO implements SeoElementInterface
         if (null !== $query && $query->getVirtualColumn('h1')) {
             return $query->getVirtualColumn('h1');
         }
-        $page = PageQuery::create()->filterById($id)->useI18nQuery($locale)->endUse()->findOne();
+        // Plain lookup, not useI18nQuery(): an inner join on the requested locale would
+        // hide the page entirely instead of letting the default language answer.
+        $page = PageQuery::create()->filterById($id)->findOne();
+        $title = $this->localizedValue($page, 'getTitle', $locale);
 
-        return $page?->getTitle() ?? ConfigQuery::read('store_name') ?? '';
+        return '' !== $title ? $title : (ConfigQuery::read('store_name') ?? '');
     }
 
     private function getPageMicroData(Page $page, Lang $lang): array
     {
-        $page->setLocale($lang->getLocale());
+        $locale = $lang->getLocale();
+        $page->setLocale($locale);
 
         $microData = [
             '@context' => 'https://schema.org/',
             '@type' => 'Guide',
             'url' => $page->getUrl(),
-            'name' => $page->getTitle(),
-            'abstract' => $page->getChapo(),
+            'name' => $this->localizedValue($page, 'getTitle', $locale),
+            'abstract' => $this->localizedValue($page, 'getChapo', $locale),
         ];
 
         return $microData;
@@ -124,12 +133,13 @@ readonly class PageSEO implements SeoElementInterface
         $breadcrumb = [];
 
         if ($id) {
-            $page = PageQuery::create()->filterById($id)->findOne()?->setlocale($this->langService->getLocale());
+            $locale = $this->langService->getLocale();
+            $page = PageQuery::create()->filterById($id)->findOne();
 
             if (null !== $page) {
                 $breadcrumb[] = [
-                    'url' => $page->getUrl(),
-                    'title' => $page->getTitle(),
+                    'url' => $page->setLocale($locale)->getUrl(),
+                    'title' => $this->localizedValue($page, 'getTitle', $locale),
                 ];
             }
         }

--- a/Service/SeoDefaultModels/ProductSEO.php
+++ b/Service/SeoDefaultModels/ProductSEO.php
@@ -33,6 +33,7 @@ use Thelia\Model\ProductSaleElementsQuery;
 
 readonly class ProductSEO implements SeoElementInterface
 {
+    use LocalizedValueTrait;
     use SEOneMicroDataTrait;
     use SmartyCompatibilityTrait;
 
@@ -81,23 +82,28 @@ readonly class ProductSEO implements SeoElementInterface
         if (null !== $query && $query->getVirtualColumn('h1')) {
             return $query->getVirtualColumn('h1');
         }
-        $product = ProductQuery::create()->filterById($id)->findOne()?->setlocale($locale);
+        $product = ProductQuery::create()->filterById($id)->findOne();
+        $title = $this->localizedValue($product, 'getTitle', $locale);
 
-        return $product?->getTitle() ?? ConfigQuery::read('store_name') ?? '';
+        return '' !== $title ? $title : (ConfigQuery::read('store_name') ?? '');
     }
 
     public function getSeoPageTitle($id): string
     {
-        $product = ProductQuery::create()->filterById($id)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $product = ProductQuery::create()->filterById($id)->findOne();
+        $title = $this->firstLocalizedValue($product, ['getMetaTitle', 'getTitle'], $locale);
 
-        return $product?->getMetaTitle() ?? $product?->getTitle() ?? SEOne::getConfigValue('title', ConfigQuery::read('store_name'), $this->langService->getLocale()) ?? '';
+        return '' !== $title ? $title : (SEOne::getConfigValue('title', ConfigQuery::read('store_name'), $locale) ?? '');
     }
 
     public function getSeoPageDesc($id): string
     {
-        $product = ProductQuery::create()->filterById($id)->findOne()?->setlocale($this->langService->getLocale());
+        $locale = $this->langService->getLocale();
+        $product = ProductQuery::create()->filterById($id)->findOne();
+        $description = $this->localizedValue($product, 'getMetaDescription', $locale);
 
-        return $product?->getMetaDescription() ?? SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $this->langService->getLocale()) ?? '';
+        return '' !== $description ? $description : (SEOne::getConfigValue('description', ConfigQuery::read('store_description'), $locale) ?? '');
     }
 
     public function getSeoMicroData($id, string $type, array $params = []): string
@@ -125,8 +131,9 @@ readonly class ProductSEO implements SeoElementInterface
     private function getProductMicroData(Product $product, Lang $lang, $relatedProducts = []): array
     {
         $request = $this->requestStack->getCurrentRequest();
+        $locale = $lang->getLocale();
 
-        $product->setLocale($lang->getLocale());
+        $product->setLocale($locale);
         $image = ProductImageQuery::create()->filterByProductId($product->getId())->orderByPosition()->find()->getFirst();
         $pse = ProductSaleElementsQuery::create()->filterByProductId($product->getId())->filterByIsDefault(1)->findOne();
         $psePrice = ProductPriceQuery::create()->filterByProductSaleElementsId($pse->getId())->findOne();
@@ -173,9 +180,9 @@ readonly class ProductSEO implements SeoElementInterface
         $microData = [
             '@context' => 'https://schema.org/',
             '@type' => 'Product',
-            'name' => $product->getTitle(),
+            'name' => $this->localizedValue($product, 'getTitle', $locale),
             'image' => $imagePath,
-            'description' => $product->getDescription(),
+            'description' => $this->localizedValue($product, 'getDescription', $locale),
             'sku' => $product->getRef(),
             'offers' => [
                 'url' => $product->getUrl(),
@@ -232,15 +239,16 @@ readonly class ProductSEO implements SeoElementInterface
                 ->filterByProductId($id)
                 ->findOne();
 
-            $product = $productCategory?->getProduct()?->setlocale($this->langService->getLocale());
+            $locale = $this->langService->getLocale();
+            $product = $productCategory?->getProduct();
 
             if (null === $product) {
                 return $breadcrumb;
             }
 
             $breadcrumb[] = [
-                'url' => $product->getUrl(),
-                'title' => $product->getTitle(),
+                'url' => $product->setLocale($locale)->getUrl(),
+                'title' => $this->localizedValue($product, 'getTitle', $locale),
             ];
             $breadcrumb = array_reverse($this->categorySEO->getCategoryPath($productCategory->getCategoryId(), $breadcrumb));
         }

--- a/Twig/Plugins/SEOneMicroDataPluginTwig.php
+++ b/Twig/Plugins/SEOneMicroDataPluginTwig.php
@@ -45,15 +45,14 @@ class SEOneMicroDataPluginTwig extends AbstractExtension
     {
         $defaultType = $view ?? $this->toolsService->getPageView() ?? '';
 
-        $defaultId = $id ?? $this->toolsService->getPageId($defaultType);
-
-        return $this->toolsService->getSeoPageTitle(view: $defaultType, view_id: $defaultId);
+        return $this->toolsService->getSeoPageTitle(view: $defaultType, view_id: $this->resolveViewId($defaultType, $id));
     }
 
     public function getSeoPageH1(?string $view = null, ?string $id = null): string
     {
         $defaultType = $view ?? $this->toolsService->getPageView() ?? '';
-        $defaultId = $id ?? $this->toolsService->getPageId($defaultType);
+        $defaultId = $this->resolveViewId($defaultType, $id);
+
         if (null === $defaultId) {
             return '';
         }
@@ -65,17 +64,18 @@ class SEOneMicroDataPluginTwig extends AbstractExtension
     {
         $defaultType = $view ?? $this->toolsService->getPageView() ?? '';
 
-        $defaultId = $id ?? $this->toolsService->getPageId($defaultType);
-
-        return $this->toolsService->getSeoPageDesc(view: $defaultType, view_id: $defaultId);
+        return $this->toolsService->getSeoPageDesc(view: $defaultType, view_id: $this->resolveViewId($defaultType, $id));
     }
 
     public function getSeoMicroData(?string $view = null, array $params = []): string
     {
         $defaultType = $view ?? $this->toolsService->getPageView() ?? '';
-        $defaultId = $params['id'] ?? $this->toolsService->getPageId($defaultType);
 
-        return $this->toolsService->getSeoMicroData(view: $defaultType, view_id: $defaultId, params: $params);
+        return $this->toolsService->getSeoMicroData(
+            view: $defaultType,
+            view_id: $this->resolveViewId($defaultType, $params['id'] ?? null),
+            params: $params
+        );
     }
 
     public function getSeoCanonical(): string
@@ -91,9 +91,24 @@ class SEOneMicroDataPluginTwig extends AbstractExtension
     public function getSeoBreadcrumb(?string $view = null, array $params = []): array
     {
         $defaultType = $view ?? $this->toolsService->getPageView() ?? '';
-        $defaultId = $params['id'] ?? $this->toolsService->getPageId($defaultType);
 
-        return $this->toolsService->getSeoBreadcrumb(view: $defaultType, view_id: $defaultId, params: $params);
+        return $this->toolsService->getSeoBreadcrumb(
+            view: $defaultType,
+            view_id: $this->resolveViewId($defaultType, $params['id'] ?? null),
+            params: $params
+        );
+    }
+
+    /**
+     * The view id reaches us as a string, either from the query string through getPageId()
+     * or from a template argument, while SeoToolsService expects ?int. Anything that is not
+     * a number means there is no SEO target to describe.
+     */
+    private function resolveViewId(string $view, mixed $id = null): ?int
+    {
+        $id ??= $this->toolsService->getPageId($view);
+
+        return is_numeric($id) ? (int) $id : null;
     }
 
     public function getSeoBreadcrumbJsonLd(?array $breadcrumb): string

--- a/Twig/Plugins/SEOneMicroDataPluginTwig.php
+++ b/Twig/Plugins/SEOneMicroDataPluginTwig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Thelia package.
  * http://www.thelia.net
@@ -14,6 +16,7 @@ namespace SEOne\Twig\Plugins;
 
 use SEOne\Service\SeoToolsService;
 use Thelia\Model\ConfigQuery;
+use Thelia\Tools\URL;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -34,7 +37,7 @@ class SEOneMicroDataPluginTwig extends AbstractExtension
             new TwigFunction('SEOnePageCanonical', [$this, 'getSeoCanonical']),
             new TwigFunction('SEOneBreadcrumb', [$this, 'getSeoBreadcrumb']),
             new TwigFunction('SEOneBreadcrumbJsonLd', [$this, 'getSeoBreadcrumbJsonLd']),
-            new TwigFunction('SEOneHreflang', [$this, 'getHreflang'])
+            new TwigFunction('SEOneHreflang', [$this, 'getHreflang']),
         ];
     }
 
@@ -95,35 +98,61 @@ class SEOneMicroDataPluginTwig extends AbstractExtension
 
     public function getSeoBreadcrumbJsonLd(?array $breadcrumb): string
     {
-        if (!$breadcrumb || empty($breadcrumb)) {
+        if (empty($breadcrumb)) {
             return '';
         }
 
         $itemListElement = [];
-        $homeItem = [
-            '@type' => 'ListItem',
-            'position' => 1,
-            'item' => [
-                '@id' => ConfigQuery::read('url_site'),
-                'name' => ConfigQuery::read('store_name'),
-            ],
-        ];
+        $position = 1;
 
-        foreach ($breadcrumb as $key => $item) {
+        foreach (array_merge([$this->getHomeItem()], $breadcrumb) as $item) {
+            $name = $item['title'] ?? null;
+
+            if (null === $name || '' === $name) {
+                continue;
+            }
+
+            $url = $item['url'] ?? null;
+
+            // @id is optional for the current page, but must never be an empty string.
+            $itemNode = (null === $url || '' === $url) ? ['name' => $name] : ['@id' => $url, 'name' => $name];
+
+            // The position is assigned here, once the home item and the breadcrumb are
+            // merged, so that the list is numbered 1..n without duplicate or hole.
             $itemListElement[] = [
                 '@type' => 'ListItem',
-                'position' => $key + 1,
-                'item' => [
-                    '@id' => $item['url'],
-                    'name' => $item['title'],
-                ],
+                'position' => $position++,
+                'item' => $itemNode,
             ];
+        }
+
+        if ([] === $itemListElement) {
+            return '';
         }
 
         return '<script type="application/ld+json">'.json_encode([
             '@context' => 'https://schema.org/',
             '@type' => 'BreadcrumbList',
-            'itemListElement' => array_merge([$homeItem], $itemListElement),
+            'itemListElement' => $itemListElement,
         ]).'</script>';
+    }
+
+    /**
+     * @return array{url: ?string, title: ?string}
+     */
+    private function getHomeItem(): array
+    {
+        $url = ConfigQuery::read('url_site');
+
+        // url_site is often left empty in development: fall back to the URL the request
+        // came in on rather than emitting an empty @id.
+        if (null === $url || '' === $url) {
+            $url = URL::getInstance()->getIndexPage();
+        }
+
+        return [
+            'url' => $url,
+            'title' => ConfigQuery::read('store_name'),
+        ];
     }
 }


### PR DESCRIPTION
# PROBLEME

# SEOne — les titres i18n ignorent le repli « langue par défaut »

**Module** : `thelia/seone-module` (`https://github.com/thelia-modules/SEOne`)
**Branche par défaut** : `main`
**Version constatée en projet** : `dev-main`, ref `ab053e86b` (2026-08-04)
**État upstream au 2026-08-07** : `52d83fb8d` (2026-08-06) — 2 commits d'avance, aucun ne traite ce sujet
**Constaté sur** : Thelia 3 (branche `twig`), thème Flexy, catalogue de démo

---

## 1. En une phrase

SEOne lit tous ses libellés i18n en Propel brut (`$model->setLocale($locale)->getTitle()`), sans jamais appliquer le réglage back-office **« Si une traduction est absente ou incomplète »** (`config.default_lang_without_translation`). Dès qu'une entité n'est pas traduite dans la langue demandée, SEOne renvoie `null` là où le core aurait renvoyé la traduction de la langue par défaut.

## 2. Symptôme reproductible

Catalogue de démo, produit 1 (« Horatio ») rangé sous `Salle à manger > Chaises`. Traductions présentes en `fr_FR` et `en_US` uniquement ; `es_ES` est une langue **visible** mais sans aucune ligne `product_i18n` / `category_i18n`. Réglage BO : `default_lang_without_translation = 1` (= `Lang::REPLACE_BY_DEFAULT_LANGUAGE`).

```
https://<site>/?view=product&lang=es_ES&product_id=1
```

| Attendu (repli configuré) | Obtenu |
|---|---|
| Fil d'Ariane `Dining Room > Chairs > Horatio` | **aucun fil d'Ariane affiché** |
| `<h1>Horatio</h1>` | `<h1>Thelia</h1>` (nom de la boutique) |
| JSON-LD `BreadcrumbList` valide | 3 items avec `"name": null` |

JSON-LD réellement émis sur la page (extrait) :

```json
{"@type":"BreadcrumbList","itemListElement":[
  {"@type":"ListItem","position":1,"item":{"@id":"","name":"Thelia"}},
  {"@type":"ListItem","position":1,"item":{"@id":".../?view=category&lang=es_ES&category_id=2","name":null}},
  {"@type":"ListItem","position":2,"item":{"@id":".../?view=category&lang=es_ES&category_id=3","name":null}},
  {"@type":"ListItem","position":3,"item":{"@id":".../?view=product&lang=es_ES&product_id=1","name":null}}]}
```

En `fr_FR`, la même URL redirige vers `/horatio-1.html` et tout s'affiche correctement. Le comportement dépend donc bien de la langue, pas de la forme non réécrite de l'URL.

> Le fil d'Ariane est **absent** et non pas vide parce que le thème filtre volontairement les items sans titre (un bouton retour sans libellé est inaffichable, et un `name: null` est invalide en données structurées). C'est le thème qui masque le symptôme ; la donnée fautive vient de SEOne.

## 3. Cause racine

`Service/SeoDefaultModels/` — chaque modèle SEO lit ses libellés directement sur l'objet Propel, dont la traduction manquante vaut `null` :

| Fichier (upstream `main`) | Ligne | Effet |
|---|---|---|
| `ProductSEO.php` | 235 → 241-244 | `getSeoBreadcrumb()` : `title` du produit à `null` |
| `CategorySEO.php` | 163 → 169-172 | `getCategoryPath()` : `title` de chaque catégorie à `null` |
| `ProductSEO.php` | 84-86 | `getSeoPageH1()` : `getTitle()` à `null` → repli sur `store_name` |
| `CategorySEO.php` | 119-121 | idem pour une catégorie |
| `ProductSEO.php` | 91, 98 | `getSeoPageTitle()` / `getSeoPageDesc()` : `<title>` et meta description |
| `FolderSEO.php`, `ContentSEO.php`, `PageSEO.php` | 73, 80, 107, 125-145 | même schéma sur les dossiers, contenus et pages |

Au total **23 appels `setLocale()` suivis de ~30 lectures de getters i18n** dans les 5 modèles SEO, aucun ne consultant la configuration de repli.

Le core, lui, applique ce réglage à chaque couche qui expose de l'i18n — et le réimplémente partout, il n'existe pas de helper unique à appeler :

- `Thelia\Model\Tools\ModelCriteriaTools::getFrontEndI18n()` (couche loops, repli fait en SQL via un LEFT JOIN sur la langue par défaut)
- `Thelia\Api\Service\API\ResourceService::formatI18ns()` (couche API)
- `Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\LocalizedTitleTrait`
- `Thelia\Api\Service\DataAccess\ProductSaleElementsAccessService::localizedTitle()`
- `Thelia\Model\CartItem` (au niveau modèle)

SEOne est le seul consommateur front à ne pas le faire.

## 4. Vérification : aucun correctif n'existe déjà

Contrôles effectués le **2026-08-07** :

- **Commits upstream** : `main` est à `52d83fb8d`, soit 2 commits devant notre ref. Les deux sont d'Alexandre Nozière (2026-08-06) et touchent bien `ProductSEO.php` / `CategorySEO.php`, mais ce sont **uniquement des sécurisations de `null`** (`findOne()?->`, sortie anticipée quand la cible SEO n'existe pas) :
  - `8d805c8db` — *fix: return 404 instead of a fatal error when the SEO target is missing*
  - `52d83fb8d` — *fix: skip the micro data event when the SEO target has none*

  Diff vérifié ligne à ligne : les `getTitle()` restent des lectures Propel brutes, sans repli.
- **Pull requests** : aucune ouverte. Les 11 PR fermées ont été passées en revue — aucune ne porte sur l'i18n ou le repli de langue (la plus proche, #8, corrige la forme du tableau `itemListElement` du JSON-LD, pas son contenu).
- **Issues** : aucune, ouverte ou fermée.
- **Recherche dans le code upstream** : aucune occurrence de `getDefaultLangWhenNoTranslationAvailable`, `REPLACE_BY_DEFAULT_LANGUAGE` ni `default_lang_without_translation` dans tout le module.

**Conclusion : sujet non traité, ni en cours de traitement.** Le correctif est à écrire.

## 5. Correctif proposé

Un helper unique, mutualisé entre les 5 modèles SEO (un trait dans `Service/SeoDefaultModels/`, à côté de `SmartyCompatibilityTrait` et `SeoneBreadcrumbTrait` qui suivent déjà ce pattern), et appelé partout à la place des lectures directes.

Reprendre la forme déjà validée en core (PR thelia/thelia#3442, mergée le 2026-08-06, `ProductSaleElementsAccessService::localizedTitle()`) — même sémantique, mêmes cas limites :

```php
private function localizedValue(ActiveRecordInterface $record, string $getter, string $locale): string
{
    $value = $record->setLocale($locale)->{$getter}();

    // Explicit emptiness test rather than ?: — "0" is a legitimate title.
    if (null !== $value && '' !== $value) {
        return $value;
    }

    $fallbackLocale = $this->fallbackLocale($locale);

    if (null !== $fallbackLocale) {
        $value = $record->setLocale($fallbackLocale)->{$getter}();
    }

    return $value ?? '';
}

private function fallbackLocale(string $currentLocale): ?string
{
    if (Lang::REPLACE_BY_DEFAULT_LANGUAGE !== (int) ConfigQuery::getDefaultLangWhenNoTranslationAvailable()) {
        return null;
    }

    $defaultLocale = Lang::getDefaultLanguage()->getLocale();

    return $defaultLocale === $currentLocale ? null : $defaultLocale;
}
```

Points d'attention pour l'implémentation :

1. **Test d'absence explicite, pas `?:` ni `??`.** Deux pièges distincts :
   - `getTitle()` renvoie `null` (pas `''`) quand la ligne i18n est absente, donc les `?? ` actuels *semblent* fonctionner — mais ils se rabattent sur `store_name`, pas sur la traduction par défaut ;
   - un titre légitimement égal à `"0"` ne doit pas être traité comme manquant.
2. **Respecter `STRICTLY_USE_REQUESTED_LANGUAGE` (valeur `0`).** Si l'admin a choisi ce mode, ne rien replier : renvoyer vide et laisser le thème décider. Le repli ne doit pas être inconditionnel.
3. **Ne pas court-circuiter le repli existant vers `store_name` / `store_description`.** Il reste pertinent quand *aucune* langue n'a de traduction ; il doit juste passer après le repli i18n, pas avant.
4. **Périmètre.** Traiter les 5 modèles d'un coup (`ProductSEO`, `CategorySEO`, `FolderSEO`, `ContentSEO`, `PageSEO`) : corriger le seul fil d'Ariane laisserait le `<h1>`, le `<title>` et les meta descriptions faux.
5. **`getUrl()` n'est pas concerné.** Sans URL réécrite dans la langue demandée, Thelia retombe sur la forme paramétrique (`?view=product&lang=es_ES&product_id=1`), ce qui est le comportement normal du core.

Test attendu : un test fonctionnel avec une entité traduite dans la langue par défaut mais pas dans la langue demandée, vérifiant le titre du fil d'Ariane dans les deux modes de configuration.

Commit suggéré : `fix: fall back to the default language when a SEO title has no translation`

## 6. Défauts adjacents, dans les mêmes fichiers

À traiter ou non selon l'appétit, mais autant les connaître avant d'ouvrir le fichier :

- **`Twig/Plugins/SEOneMicroDataPluginTwig.php:96-128`** — deux items du `BreadcrumbList` portent `position: 1` : l'accueil est câblé en dur à `1`, puis la boucle repart de `$key + 1`. La dernière position vaut `N` au lieu de `N+1`. Invalide pour Google.
- **Même fichier, ligne 107** — `'@id' => ConfigQuery::read('url_site')` sort `""` quand `url_site` n'est pas renseigné en base (cas courant en dev), ce qui produit un `@id` vide.
- **Même fichier** — aucun filtrage des items sans titre : un `"name": null` part tel quel dans le JSON-LD. Une garde ici protégerait indépendamment du correctif i18n.
- **`Event/SEOneBreadcrumbEvent.php`** — la propriété `$breadcrumb` n'est jamais déclarée : elle est créée dynamiquement par `setBreadcrumb()` (déprécié depuis PHP 8.2), et `getBreadcrumb(): array` lèverait une erreur si aucun listener n'avait alimenté l'événement.

## 7. Contournement projet, si le correctif doit attendre

`SeoToolsService::getSeoBreadcrumb()` dispatche `SEOneBreadcrumbEvent::BETTER_SEO_BREADCRUMB`, le listener par défaut est en priorité `128`, et l'événement expose un `setBreadcrumb()` public. Un listener projet de priorité inférieure peut donc post-traiter le fil d'Ariane et re-remplir les titres manquants depuis la langue par défaut, sans toucher au module.

À ne considérer que comme un pansement : ça ne couvre ni le `<h1>`, ni le `<title>`, ni les meta descriptions, qui passent par d'autres événements.

## 8. Reproduction rapide

```sql
-- Une langue visible sans traduction du catalogue suffit
SELECT id, code, locale, visible FROM lang;
SELECT locale, title FROM product_i18n WHERE id = 1;
SELECT value FROM config WHERE name = 'default_lang_without_translation'; -- doit valoir 1
```

```bash
curl -sk "https://<site>/?view=product&lang=es_ES&product_id=1" | grep -oE '<h1[^>]*>[^<]*</h1>'
# attendu : le titre du produit dans la langue par défaut
# obtenu  : <h1 class="...">Thelia</h1>
```
### Features

- Support Standard Markdown / CommonMark and GFM(GitHub Flavored Markdown);
- Full-featured: Real-time Preview, Image (cross-domain) upload, Preformatted text/Code blocks/Tables insert, Code fold, Search replace, Read only, Themes, Multi-languages, L18n, HTML entities, Code syntax highlighting...;
- Markdown Extras : Support ToC (Table of Contents), Emoji, Task lists, @Links...;
- Compatible with all major browsers (IE8+), compatible Zepto.js and iPad;
- Support identification, interpretation, fliter of the HTML tags;
- Support TeX (LaTeX expressions, Based on KaTeX), Flowchart and Sequence Diagram of Markdown extended syntax;
- Support AMD/CMD (Require.js & Sea.js) Module Loader, and Custom/define editor plugins;


