### PR TITLE
Read request inputs explicitly instead of the deprecated Request::get()

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <authors>
         <author>
             <name>df</name>

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <authors>
         <author>
             <name>df</name>

--- a/Controller/SEOneController.php
+++ b/Controller/SEOneController.php
@@ -38,11 +38,15 @@ class SEOneController extends BaseAdminController
 
         $seoForm = $this->validateForm($form);
 
-        $object_id = $request->get('object_id');
-        $object_type = $request->get('object_type');
+        // The back-office form posts to path('seone_seo_save', {object_id, object_type,
+        // lang_id}), so these three arrive in the query string, not in the body — reading
+        // them from the body only would break saving. Query first, then body, which is the
+        // order the Request::get() this replaces used.
+        $object_id = $request->query->get('object_id') ?? $request->request->get('object_id');
+        $object_type = $request->query->get('object_type') ?? $request->request->get('object_type');
 
         $lang = LangQuery::create()
-            ->filterById($request->get('lang_id'))
+            ->filterById($request->query->get('lang_id') ?? $request->request->get('lang_id'))
             ->findOne();
 
         if (null === $objectSeo = SeoneQuery::create()

--- a/EventListeners/CanonicalUrlListener.php
+++ b/EventListeners/CanonicalUrlListener.php
@@ -17,6 +17,7 @@ use SEOne\Event\SEOneUrlEvents;
 use SEOne\Model\SeoneQuery;
 use SEOne\SEOne;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\HttpFoundation\Session\Session;
@@ -76,9 +77,9 @@ class CanonicalUrlListener implements EventSubscriberInterface
             $canonicalUrl .= $path;
 
             $canonicalUrl = rtrim($canonicalUrl, '/');
-            $view = $request->get('_view');
+            $view = $this->inputValue($request, '_view');
 
-            $page = $request->get('page');
+            $page = $this->inputValue($request, 'page');
             if (null !== $page && $page !== '1' && \in_array($view, ['category', 'folder'])) {
                 $canonicalUrl .= '?page='.$page;
             }
@@ -212,20 +213,49 @@ class CanonicalUrlListener implements EventSubscriberInterface
         /** @var Request $request */
         $request = $this->requestStack->getCurrentRequest();
 
-        $view = $request->get('view');
+        $view = $this->inputValue($request, 'view');
         if (null === $view) {
-            $view = $request->get('_view');
+            $view = $this->inputValue($request, '_view');
         }
         if (null === $view) {
             return null;
         }
 
-        $id = $request->get($view.'_id');
+        $id = $this->inputValue($request, $view.'_id');
 
         if (null === $id) {
             return null;
         }
 
         return compact('view', 'id');
+    }
+
+    /**
+     * Reads a request input from the same sources, and in the same order, as the
+     * Request::get() this replaces (deprecated since Symfony 7.4).
+     *
+     * The three sources are all in use here: the routers put `_view` in the attributes,
+     * RewritingRouter puts `<view>_id` and the extra parameters such as `page` in the
+     * query, and a legacy `?view=...` URL or a posted form can carry either.
+     *
+     * Values are read through all(), like Request::get() did, so that a crafted
+     * `?page[]=1` yields no value instead of the HTTP 400 that InputBag::get() would
+     * raise on a front-office page.
+     *
+     * Typed against the base Symfony request on purpose: a sub-request rendered through
+     * render(controller(...)) is not a Thelia request, and this listener runs on whatever
+     * request is current.
+     */
+    private function inputValue(HttpRequest $request, string $key): ?string
+    {
+        foreach ([$request->attributes, $request->query, $request->request] as $bag) {
+            $value = $bag->all()[$key] ?? null;
+
+            if (is_scalar($value)) {
+                return (string) $value;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
`CanonicalUrlListener` runs on every front-office page, so its four `Request::get()` calls alone accounted for tens of thousands of deprecation log lines a day on a live shop — around 50 MB of logs per day on a shared host. Symfony 7.4 deprecates the method.

### What the inputs actually are

All three input bags are genuinely in use, so the replacement keeps `Request::get()`'s exact order (attributes → query → body):

| Input | Where it comes from |
|---|---|
| `_view` | attributes (`RewritingRouter`, `DefaultController::noAction`) |
| `<view>_id` | query (`RewritingRouter` calls `$request->query->set(...)`), or attributes on the non-rewritten path |
| `page` | query (extra rewriting parameters) |
| `view` | query or body, for legacy `?view=product` URLs |

Two details worth reviewing:

- values are read through `all()`, like `Request::get()` did, so a crafted `?page[]=1` yields no value instead of the HTTP 400 that `InputBag::get()` raises on a non-scalar — a public front-office page must not answer 400 on a forged query string;
- the helper is typed against the base Symfony request, not the Thelia one: a sub-request rendered through `render(controller(...))` is not a Thelia request, and this listener runs on whatever request is current.

The back-office save action reads its three inputs from the **query**, which is where `path('seone_seo_save', {object_id, object_type, lang_id})` puts them — reading them from the body would have broken saving.

### Checks

- Behaviour compared against the previous implementation on five request shapes (rewritten product page, paginated category, legacy `?view=`, home, view without id): identical results, 0 deprecations emitted instead of 2-3 per call.
- Run on a Thelia 3 instance with the demo data: canonical still rendered on the home, on a content page and on a category; `?page=2` is appended and `?page=1` is not.
