### PR TITLE
fix: declare nullable parameters explicitly for PHP 8.4

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <authors>
         <author>
             <name>df</name>

--- a/EventListeners/CanonicalUrlListener.php
+++ b/EventListeners/CanonicalUrlListener.php
@@ -193,7 +193,7 @@ class CanonicalUrlListener implements EventSubscriberInterface
         return $url;
     }
 
-    protected function getSiteBaseUrlForLocale(Lang $lang = null)
+    protected function getSiteBaseUrlForLocale(?Lang $lang = null)
     {
         if (null === $lang) {
             $lang = $this->requestStack->getCurrentRequest()->getSession()->getLang();


### PR DESCRIPTION
## Why

On PHP 8.4, declaring a parameter with a non-nullable type and a `null` default
(`function f(Foo $bar = null)`) is deprecated: *"Implicitly marking parameter
$bar as nullable is deprecated, specify `?Foo` explicitly"*.

The Flexy theme CI runs on PHP 8.3 **and** 8.4; the 8.4 leg reported 21 such
deprecations across the module set, none from the core nor the theme.

## What

Each affected parameter is rewritten as an explicit `?Type $x = null`.

## Impact

None functionally. `Foo $bar = null` and `?Foo $bar = null` describe the exact
same accepted type set, on 8.3 as on 8.4 — the change only makes the nullability
explicit so 8.4 stops emitting the notice. No behaviour, no call site, no
signature compatibility changes.

The overridden lifecycle methods of `Thelia\Module\BaseModule` already declare
`?ConnectionInterface $con = null` in the core, so these overrides now match the
parent exactly instead of relying on the implicit coercion.

Patch version bump so the fix reaches installed setups.
